### PR TITLE
feat: make reasoning summary configurable via settings

### DIFF
--- a/src/vibecore/agents/default.py
+++ b/src/vibecore/agents/default.py
@@ -56,9 +56,9 @@ def create_default_agent(mcp_servers: list["MCPServer"] | None = None) -> Agent[
     instructions = prompt_with_handoff_instructions(instructions)
 
     # Configure reasoning based on settings
-    reasoning_config = Reasoning(summary="auto")
+    reasoning_config = Reasoning(summary=settings.reasoning_summary)
     if settings.reasoning_effort is not None:
-        reasoning_config = Reasoning(effort=settings.reasoning_effort, summary="auto")
+        reasoning_config = Reasoning(effort=settings.reasoning_effort, summary=settings.reasoning_summary)
 
     return Agent[VibecoreContext](
         name="Vibecore Agent",

--- a/src/vibecore/agents/task_agent.py
+++ b/src/vibecore/agents/task_agent.py
@@ -60,7 +60,7 @@ def create_task_agent(prompt: str) -> Agent[VibecoreContext]:
         model=settings.model,
         model_settings=ModelSettings(
             include_usage=True,  # Ensure token usage is tracked in streaming mode
-            reasoning=Reasoning(summary="auto"),
+            reasoning=Reasoning(summary=settings.reasoning_summary),
         ),
         handoffs=[],
     )

--- a/src/vibecore/main.py
+++ b/src/vibecore/main.py
@@ -268,7 +268,7 @@ class VibecoreApp(App):
                 if reasoning_effort is not None:
                     # Create a copy of the agent with updated model settings
                     current_settings = self.agent.model_settings or ModelSettings()
-                    new_reasoning = Reasoning(effort=reasoning_effort, summary="auto")
+                    new_reasoning = Reasoning(effort=reasoning_effort, summary=settings.reasoning_summary)
                     updated_settings = ModelSettings(
                         include_usage=current_settings.include_usage,
                         reasoning=new_reasoning,

--- a/src/vibecore/settings.py
+++ b/src/vibecore/settings.py
@@ -109,6 +109,10 @@ class Settings(BaseSettings):
         default=None,
         description="Default reasoning effort level for agents (null, 'minimal', 'low', 'medium', 'high')",
     )
+    reasoning_summary: Literal["auto", "concise", "detailed"] | None = Field(
+        default="auto",
+        description="Reasoning summary mode ('auto', 'concise', 'detailed', or null for off)",
+    )
 
     # Session configuration
     session: SessionSettings = Field(

--- a/src/vibecore/settings.py
+++ b/src/vibecore/settings.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from agents import Model, OpenAIChatCompletionsModel
 from agents.models.multi_provider import MultiProvider
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
 
 from vibecore.models import AnthropicModel
@@ -111,8 +111,16 @@ class Settings(BaseSettings):
     )
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = Field(
         default="auto",
-        description="Reasoning summary mode ('auto', 'concise', 'detailed', or null for off)",
+        description="Reasoning summary mode ('auto', 'concise', 'detailed', or 'off')",
     )
+
+    @field_validator("reasoning_summary", mode="before")
+    @classmethod
+    def validate_reasoning_summary(cls, v):
+        """Convert string 'null' to None for reasoning_summary field."""
+        if v == "off" or v == "":
+            return None
+        return v
 
     # Session configuration
     session: SessionSettings = Field(


### PR DESCRIPTION
Add reasoning_summary setting to control how reasoning summaries are displayed.
Users can now configure this as 'auto' (default), 'concise', 'detailed', or null to disable.

- Add reasoning_summary field to Settings with proper type annotations
- Update default_agent, task_agent, and main.py to use the new setting
- Replace hardcoded "auto" values with configurable setting
- Maintain backward compatibility with "auto" as default